### PR TITLE
Fix logout clear session

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Attention à éviter d'inclure les informations sensibles du client (ID/Secret) 
 D'autres éléments de configuration peuvent être ajoutés dans le dictionnaire pour personnaliser les adresses des routes exposées :
 - `authorization_route` : route à utiliser pour générer la route du module OAuth qui renvoie l'adresse d'autorisation du portail [défaut : `<url_path>/authlink`]
 - `callback_route` : route qui récupère la redirection avec le code d'autorisation [défaut : `<url_path>/callback`]
-- `logout_route` : route qui supprime le token de la session Django [défaut : `<url_path>/logout`]
+- `logout_route` : route qui supprime la session Django [défaut : `<url_path>/logout`]
 - `login_redirect` : adresse sur laquelle rediriger l'utilisateur après la récupération des tokens [défaut : `/`]
 - `logout_redirect` : adresse sur laquelle rediriger l'utilisateur après la déconnexion [défaut : `/`]
 

--- a/oauth_pda_app/views.py
+++ b/oauth_pda_app/views.py
@@ -77,8 +77,9 @@ def user_logout(request):
     """
     Vue qui supprime la session de l'utilisateur
     """
-    if 'token' in request.session:
-        request.session.pop('token')
+
+    # supprime tous les éléments de la session (incluant le token)
+    request.session.clear()
 
     # redirige à l'endroit indiqué dans la configuration, ou à l'accueil
     # par défaut


### PR DESCRIPTION
Plutôt que de supprimer seulement le token, on peut supprimer tout le contenu de la session lors de la déconnexion, ça évite de garder des choses et on sait dans le backend que si les éléments ne sont plus là c'est que l'utilisateur est déconnecté.